### PR TITLE
Make all output and concatenation consistent

### DIFF
--- a/bench/JavaPort.java
+++ b/bench/JavaPort.java
@@ -10,7 +10,7 @@ public class JavaPort {
 	try {
 	    String line = null;
 	    while ((line = reader.readLine()) != null) {
-		System.out.print("Received message: '" + line + "'");
+		System.out.print("Responding to " + line);
 		System.out.flush();
 	    }
 	} catch(IOException e) {

--- a/bench/go_port.go
+++ b/bench/go_port.go
@@ -11,6 +11,6 @@ func main() {
 
   for {
     text, _ := reader.ReadString('\n')
-    fmt.Println("responding to", text)
+    fmt.Println("Responding to", text)
   }
 }

--- a/bench/node_port.js
+++ b/bench/node_port.js
@@ -1,5 +1,5 @@
 const readline = require('readline');
 
 process.stdin.on('data', d => {
-  process.stdout.write(`responding to: '${d}'\n`);
+  process.stdout.write(`Responding to ${d}\n`);
 });

--- a/bench/ocaml_port.ml
+++ b/bench/ocaml_port.ml
@@ -1,6 +1,6 @@
 let rec main () =
   let text = try read_line () with _ -> exit 0 in
-  let () = print_string "responding to " in
+  let () = print_string "Responding to " in
   let () = print_endline text in
   main ()
 

--- a/bench/rust_port.rs
+++ b/bench/rust_port.rs
@@ -7,8 +7,8 @@ fn main() {
         let mut text = String::new();
         match io::stdin().read_line(&mut text) {
             Ok(0) => break,
-            //Ok(_size) => println!("responding to {}", text),
-            Ok(_size) => { let _ = handle.write_fmt(format_args!("responding to {}", text)); }
+            //Ok(_size) => println!("Responding to {}", text),
+            Ok(_size) => { let _ = handle.write_fmt(format_args!("Responding to {}", text)); }
             Err(_err) => break,
         }
     }


### PR DESCRIPTION
Changed all output to print `Responding to`.

Also, minimise string concatenation to reduce impact of string implementation on benchmark.